### PR TITLE
Composite keys to SQS

### DIFF
--- a/src/idempotency-sqs-wrapper.ts
+++ b/src/idempotency-sqs-wrapper.ts
@@ -1,4 +1,4 @@
-import { SQS } from "aws-sdk";
+import SQS from "aws-sdk/clients/sqs";
 import { Providers } from "./providers";
 import { DynamoDB } from "./providers/dynamoDB";
 

--- a/src/idempotency-sqs-wrapper.ts
+++ b/src/idempotency-sqs-wrapper.ts
@@ -1,4 +1,4 @@
-import SQS from "aws-sdk/clients/sqs";
+import { SQS } from "aws-sdk";
 import { Providers } from "./providers";
 import { DynamoDB } from "./providers/dynamoDB";
 
@@ -21,7 +21,55 @@ export interface IdempotencySQSOptions {
   provider: IdempotencySQSOptionsProviderDynamoDB;
   queue: IdempotencySQSOptionsQueue;
   ttl?: number;
+  id: IdempotencySQSOptionsId;
 }
+
+interface IdempotencySQSOptionsMessageId {
+  from: "messageId";
+}
+
+interface IdempotencySQSOptionsEvent {
+  from: "event";
+  name: Array<string>;
+}
+
+type IdempotencySQSOptionsId =
+  | IdempotencySQSOptionsMessageId
+  | IdempotencySQSOptionsEvent;
+
+const isEmpty = (value: any): boolean =>
+  value === null || value === undefined || value === "";
+
+const getMessageId = (record: any, options: IdempotencySQSOptionsId): any => {
+  const messageId = record.messageId;
+
+  if (options.from === "messageId") {
+    return messageId;
+  }
+
+  const body = JSON.parse(record.body);
+  const message = JSON.parse(body.Message);
+
+  let id: string = "";
+  if (!isEmpty(options.name)) {
+    options.name.forEach((value) => {
+      let keys = value.split(".");
+      let messageValue: any = message;
+
+      if (!isEmpty(keys)) {
+        for (let key of keys) {
+          if (messageValue[key] !== Object(messageValue[key])) {
+            id += messageValue[key];
+            break;
+          }
+          messageValue = messageValue[key];
+        }
+      }
+    });
+  }
+
+  return isEmpty(id) ? messageId : id;
+};
 
 export const idempotencySQSWrapper = (
   options: IdempotencySQSOptions
@@ -37,7 +85,7 @@ export const idempotencySQSWrapper = (
     const newRecords = [];
 
     for (const record of event.Records) {
-      const messageId = record.messageId;
+      const messageId = getMessageId(record, options.id);
 
       const hasProcessed = await provider.isProcessing(messageId);
 

--- a/src/idempotency-sqs-wrapper.ts
+++ b/src/idempotency-sqs-wrapper.ts
@@ -50,14 +50,14 @@ const getMessageId = (record: any, options: IdempotencySQSOptionsId): any => {
   const body = JSON.parse(record.body);
   const message = JSON.parse(body.Message);
 
-  let id: string = "";
+  let id = "";
   if (!isEmpty(options.name)) {
     options.name.forEach((value) => {
-      let keys = value.split(".");
+      const keys = value.split(".");
       let messageValue: any = message;
 
       if (!isEmpty(keys)) {
-        for (let key of keys) {
+        for (const key of keys) {
           if (messageValue[key] !== Object(messageValue[key])) {
             id += messageValue[key];
             break;

--- a/test/idempotency-sqs-wrapper.spec.ts
+++ b/test/idempotency-sqs-wrapper.spec.ts
@@ -2,7 +2,6 @@
 import faker from "faker";
 import nock from "nock";
 import { idempotencySQSWrapper, Providers } from "../src";
-import { Providers } from "../src/providers";
 
 describe("idempotency-sqs-wrapper", () => {
   const mockNow = Date.now();

--- a/test/idempotency-sqs-wrapper.spec.ts
+++ b/test/idempotency-sqs-wrapper.spec.ts
@@ -1,7 +1,9 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-import faker from "faker";
-import nock from "nock";
-import { idempotencySQSWrapper, Providers } from "../src";
+import faker = require("faker");
+import nock = require("nock");
+import { idempotencySQSWrapper } from "../src/idempotency-sqs-wrapper";
+import { Providers } from "../src/providers";
+jest.setTimeout(10000);
 
 describe("idempotency-sqs-wrapper", () => {
   const mockNow = Date.now();
@@ -17,6 +19,124 @@ describe("idempotency-sqs-wrapper", () => {
   });
 
   describe("dynamoDB", () => {
+    it("Should pass all the records if they aren't executed yet and the id is a group of informations", async () => {
+      // Given
+      const endpointDynamo = faker.internet.url();
+      const endpointSQS = faker.internet.url();
+      const messageId = faker.random.uuid();
+      const internalHandler = jest.fn();
+      const ttl = faker.random.number();
+      const tableName = faker.random.word();
+
+      const handler = idempotencySQSWrapper({
+        handler: internalHandler,
+        provider: {
+          region: faker.random.word(),
+          tableName,
+          endpoint: endpointDynamo,
+          name: Providers.DynamoDB,
+        },
+        queue: {
+          url: endpointSQS,
+          region: faker.random.word(),
+        },
+        ttl,
+        id: {
+          from: "event",
+          name: ["stream.id", "event.eventType"],
+        },
+      });
+      const expectedTtl = String(Math.floor(mockNow / 1000) + ttl);
+      const expectedValidTime = String(Math.floor(mockNow / 1000) - ttl);
+      nock(endpointDynamo)
+        .post("/", {
+          ConditionExpression:
+            "attribute_not_exists(messageId) or (#ttl < :validTime)",
+          ExpressionAttributeNames: {
+            "#ttl": "ttl",
+          },
+          ExpressionAttributeValues: {
+            ":validTime": { N: expectedValidTime },
+          },
+          Item: {
+            messageId: {
+              S: "1474245c-414e-43b5-bb6a-c9690c5579a0ISSUED_BOLETO",
+            },
+            ttl: { N: expectedTtl },
+          },
+          TableName: tableName,
+        })
+        .reply(200);
+      const bodyMessage =
+        '{\n  "Type" : "Notification",\n  "MessageId" : "522a4e99-206a-5543-882a-190be7f974c5",\n  "TopicArn" : "arn:aws:sns:us-east-1:773374622004:payment-boletos-dev",\n  "Message" : "{\\"event\\":{\\"commitTimestamp\\":1593016163521,\\"eventType\\":\\"ISSUED_BOLETO\\"},\\"stream\\":{\\"aggregation\\":\\"BOLETO\\",\\"id\\":\\"1474245c-414e-43b5-bb6a-c9690c5579a0\\"}}",\n  "Timestamp" : "2020-07-22T23:01:39.707Z",\n  "SignatureVersion" : "1",\n  "Signature" : "dTJ202lG2N27UaQt3U3J1OExkeAMHu+7rPVcJf8DlQ20qxCswHCYXfuY7/Ql8VSWYPgQdoQi7s83mMlRcXLo0p2blysit2bhzWeTDcu0KTglHHmVScbeaRyZYecSFG2lZAYL6YW/Pnx+XQrT+drDqu6JMfGF297qDeHiaJb/PKlRlGhUzRi7i8srCefOrKmHvGuGruefW6RsGvt5kfupxqj92GYTvEDdojA0a4CB6xEKHqIztX0dPrtIGZiZD4xfmgXDWeXxZAnmXwSERnR2aiapUR/N4+yCB8Sj8dgGwMAaJ6sDf5v9vS8Ef91NH6sVQ6/KKgBDq4PP+koiaKg5Kw==",\n  "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-a86cb10b4e1f29c941702d737128f7b6.pem",\n  "UnsubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:773374622004:boletos-dev:5bc20359-a627-4f48-9d87-8896559a9d29",\n  "MessageAttributes" : {\n    "eventType" : {"Type":"String","Value":"ISSUED_BOLETO"}\n  }\n}';
+      const event = { Records: [{ messageId, body: bodyMessage }] };
+      const context = {};
+
+      // When
+      await handler(event, context);
+
+      // Then
+      expect(internalHandler).toHaveBeenCalledWith(event, context);
+    });
+
+    it("Should pass all the records if they aren't executed yet and the id is not messageId", async () => {
+      // Given
+      const endpointDynamo = faker.internet.url();
+      const endpointSQS = faker.internet.url();
+      const messageId = faker.random.uuid();
+      const internalHandler = jest.fn();
+      const ttl = faker.random.number();
+      const tableName = faker.random.word();
+
+      const handler = idempotencySQSWrapper({
+        handler: internalHandler,
+        provider: {
+          region: faker.random.word(),
+          tableName,
+          endpoint: endpointDynamo,
+          name: Providers.DynamoDB,
+        },
+        queue: {
+          url: endpointSQS,
+          region: faker.random.word(),
+        },
+        ttl,
+        id: {
+          from: "event",
+          name: ["stream.id"],
+        },
+      });
+      const expectedTtl = String(Math.floor(mockNow / 1000) + ttl);
+      const expectedValidTime = String(Math.floor(mockNow / 1000) - ttl);
+      nock(endpointDynamo)
+        .post("/", {
+          ConditionExpression:
+            "attribute_not_exists(messageId) or (#ttl < :validTime)",
+          ExpressionAttributeNames: {
+            "#ttl": "ttl",
+          },
+          ExpressionAttributeValues: {
+            ":validTime": { N: expectedValidTime },
+          },
+          Item: {
+            messageId: { S: "1474245c-414e-43b5-bb6a-c9690c5579a0" },
+            ttl: { N: expectedTtl },
+          },
+          TableName: tableName,
+        })
+        .reply(200);
+      const bodyMessage =
+        '{\n  "Type" : "Notification",\n  "MessageId" : "522a4e99-206a-5543-882a-190be7f974c5",\n  "TopicArn" : "arn:aws:sns:us-east-1:773374622004:payment-boletos-dev",\n  "Message" : "{\\"event\\":{\\"commitTimestamp\\":1593016163521,\\"eventType\\":\\"ISSUED_BOLETO\\"},\\"stream\\":{\\"aggregation\\":\\"BOLETO\\",\\"id\\":\\"1474245c-414e-43b5-bb6a-c9690c5579a0\\"}}",\n  "Timestamp" : "2020-07-22T23:01:39.707Z",\n  "SignatureVersion" : "1",\n  "Signature" : "dTJ202lG2N27UaQt3U3J1OExkeAMHu+7rPVcJf8DlQ20qxCswHCYXfuY7/Ql8VSWYPgQdoQi7s83mMlRcXLo0p2blysit2bhzWeTDcu0KTglHHmVScbeaRyZYecSFG2lZAYL6YW/Pnx+XQrT+drDqu6JMfGF297qDeHiaJb/PKlRlGhUzRi7i8srCefOrKmHvGuGruefW6RsGvt5kfupxqj92GYTvEDdojA0a4CB6xEKHqIztX0dPrtIGZiZD4xfmgXDWeXxZAnmXwSERnR2aiapUR/N4+yCB8Sj8dgGwMAaJ6sDf5v9vS8Ef91NH6sVQ6/KKgBDq4PP+koiaKg5Kw==",\n  "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-a86cb10b4e1f29c941702d737128f7b6.pem",\n  "UnsubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:773374622004:boletos-dev:5bc20359-a627-4f48-9d87-8896559a9d29",\n  "MessageAttributes" : {\n    "eventType" : {"Type":"String","Value":"ISSUED_BOLETO"}\n  }\n}';
+      const event = { Records: [{ messageId, body: bodyMessage }] };
+      const context = {};
+
+      // When
+      await handler(event, context);
+
+      // Then
+      expect(internalHandler).toHaveBeenCalledWith(event, context);
+    });
+
     it("Should pass all the records if they aren't executed yet", async () => {
       // Given
       const endpointDynamo = faker.internet.url();
@@ -38,6 +158,9 @@ describe("idempotency-sqs-wrapper", () => {
           region: faker.random.word(),
         },
         ttl,
+        id: {
+          from: "messageId",
+        },
       });
       const expectedTtl = String(Math.floor(mockNow / 1000) + ttl);
       const expectedValidTime = String(Math.floor(mockNow / 1000) - ttl);
@@ -87,6 +210,9 @@ describe("idempotency-sqs-wrapper", () => {
           region: faker.random.word(),
         },
         ttl,
+        id: {
+          from: "messageId",
+        },
       });
       const expectedTtl = String(Math.floor(mockNow / 1000) + ttl);
       const expectedValidTime = String(Math.floor(mockNow / 1000) - ttl);
@@ -137,6 +263,9 @@ describe("idempotency-sqs-wrapper", () => {
         queue: {
           url: endpointSQS,
           region: faker.random.word(),
+        },
+        id: {
+          from: "messageId",
         },
       });
       const expectedTtl = String(Math.floor(mockNow / 1000) + defaultTTL);

--- a/test/idempotency-sqs-wrapper.spec.ts
+++ b/test/idempotency-sqs-wrapper.spec.ts
@@ -1,9 +1,8 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-import faker = require("faker");
-import nock = require("nock");
-import { idempotencySQSWrapper } from "../src/idempotency-sqs-wrapper";
+import faker from "faker";
+import nock from "nock";
+import { idempotencySQSWrapper, Providers } from "../src";
 import { Providers } from "../src/providers";
-jest.setTimeout(10000);
 
 describe("idempotency-sqs-wrapper", () => {
   const mockNow = Date.now();


### PR DESCRIPTION
We need that the idempotency's key be some fields from the message. 
- This key can be just one field from the message or the combination of fields.

Example of usage:

```
export const receiver = idempotencySQSWrapper({
    handler: handler,
    provider: {
        name: Providers.DynamoDB,
        region: configuration.awsRegion,
        tableName: configuration.idempotencyTableName,
    },
    ttl: parseInt(configuration.idempotencyTableTtl, 10), // ttl in seconds
    queue: {
        url: configuration.subscribeUrl,
        region: configuration.awsRegion,
    },
    id: {
        from: 'event',
        name: ['stream.id', 'event.eventType']
    }
});
```